### PR TITLE
Fix building assets when deploying on production

### DIFF
--- a/conf/webpack.prod.js
+++ b/conf/webpack.prod.js
@@ -23,7 +23,12 @@ module.exports = merge(common, {
       {
         test: /\.(scss|css)$/,
         use: [
-          MiniCssExtractPlugin.loader,
+          {
+            loader: MiniCssExtractPlugin.loader,
+            options: {
+              publicPath: "/static",
+            },
+          },
           {
             loader: "css-loader",
             options: {


### PR DESCRIPTION
https://github.com/hoangmirs/go-scraper/issues/??

## What happened 👀

Got this error when building assets on production
```
Module build failed (from ./node_modules/mini-css-extract-plugin/dist/loader.js):
Error: Automatic publicPath is not supported in this browser
```
https://github.com/hoangmirs/go-scraper/runs/1782250351?check_suite_focus=true

## Insight 📝

Found [this link](https://stackoverflow.com/questions/64294706/webpack5-automatic-publicpath-is-not-supported-in-this-browser)

## Proof Of Work 📹

Tested on local machine