### PR TITLE
Fix: CSS was not built due to missing config files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,7 @@ FROM  node:14.15-alpine as assets-builder
 
 WORKDIR /assets
 
-COPY ./package.json ./package-lock.json ./
-COPY ./conf/webpack.*js ./conf/
-COPY ./assets/. ./assets/
+COPY . .
 
 RUN npm install && npm run build
 
@@ -28,7 +26,7 @@ RUN go build
 FROM alpine
 
 COPY . .
-COPY --from=assets-builder /assets/static/. ./static/
+COPY --from=assets-builder /assets/static ./static
 COPY --from=go-builder /app/go-scraper ./
 
 EXPOSE 8080


### PR DESCRIPTION
## What happened 👀

CSS was not built due to missing config files

## Insight 📝

- When copying the files for assets building in Dockerfile, I forgot to add some configuration files (tailwind, postcss) therefore the CSS was built incorrectly
- Just copy all files to make sure that we can build them properly

## Proof Of Work 📹
Link: https://go-scraper-staging.herokuapp.com/register

Before:
![Go_Scraper](https://user-images.githubusercontent.com/7344405/106583399-a3e2de80-6577-11eb-995c-7f20eb0d4673.png)

After:
![Go_Scraper](https://user-images.githubusercontent.com/7344405/106583474-b9580880-6577-11eb-9806-a81d70dad3f6.png)

