### PR TITLE
[Frontend] As a user, I can see the report of each keyword

### DIFF
--- a/assets/images/icons/website.svg
+++ b/assets/images/icons/website.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+</svg>

--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -6,7 +6,9 @@ import "../stylesheets/app-utilities.scss";
 // Stimulus
 import { Application } from "stimulus";
 import { definitionsFromContext } from "stimulus/webpack-helpers";
+import { Tabs } from "tailwindcss-stimulus-components";
 
 const application = Application.start();
 const context = require.context("./controllers", true, /\.js$/);
 application.load(definitionsFromContext(context));
+application.register("tabs", Tabs);

--- a/assets/stylesheets/components/_index.scss
+++ b/assets/stylesheets/components/_index.scss
@@ -4,4 +4,5 @@
 @import './_custom-link';
 @import './_flash-message';
 @import './_pagination';
+@import './_tab-link';
 @import './_table-keyword';

--- a/assets/stylesheets/components/_tab-link.scss
+++ b/assets/stylesheets/components/_tab-link.scss
@@ -1,0 +1,25 @@
+.tab-link {
+  &__title {
+    @apply mt-4 mb-2 text-gray-600 text-base font-bold;
+  }
+
+  &__button-tab-list {
+    @apply list-none flex border-b;
+  }
+
+  &__button-tab {
+    @apply bg-white inline-block py-2 px-4 text-green-500 hover:text-green-700 font-semibold no-underline;
+
+    &--active {
+      @apply -mb-px border-l border-t border-r rounded-t;
+    }
+  }
+
+  &__content {
+    @apply py-4 px-4 border-l border-b border-r overflow-scroll;
+  }
+
+  &__list-link {
+    @apply list-decimal px-4;
+  }
+}

--- a/assets/stylesheets/screens/_keyword.scss
+++ b/assets/stylesheets/screens/_keyword.scss
@@ -22,3 +22,25 @@ body.keyword.post {
     }
   }
 }
+
+body.keyword.show {
+  .keyword-wrapper {
+    @apply relative;
+  }
+
+  .keyword-title {
+    @apply text-gray-800 text-xl font-bold;
+  }
+
+  .keyword-date {
+    @apply inline-block pt-2;
+  }
+
+  .button-html-page {
+    @apply w-8 absolute top-3 right-3;
+
+    &:hover {
+      @apply text-green-500;
+    }
+  }
+}

--- a/bootstrap/view.go
+++ b/bootstrap/view.go
@@ -13,7 +13,7 @@ import (
 var templateFunctions = map[string]interface{}{
 	"render_file": renderFile,
 	"render_icon": renderIcon,
-	"dict":        dict,
+	"args":        args,
 }
 
 // SetUpTemplateFunction register additional template functions
@@ -50,19 +50,19 @@ func renderIcon(iconName string, options ...string) template.HTML {
 	return web.Str2html(htmlString)
 }
 
-func dict(values ...interface{}) (map[string]interface{}, error) {
+func args(values ...interface{}) (map[string]interface{}, error) {
 	if len(values) % 2 != 0 {
-		return nil, errors.New("invalid dict call")
+		return nil, errors.New("invalid args call")
 	}
 
-	dict := make(map[string]interface{}, len(values) / 2)
+	args := make(map[string]interface{}, len(values) / 2)
 	for i := 0; i < len(values); i += 2 {
 		key, ok := values[i].(string)
 		if !ok {
-			return nil, errors.New("dict keys must be strings")
+			return nil, errors.New("args keys must be strings")
 		}
-		dict[key] = values[i + 1]
+		args[key] = values[i + 1]
 	}
 
-	return dict, nil
+	return args, nil
 }

--- a/bootstrap/view.go
+++ b/bootstrap/view.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"errors"
 	"fmt"
 	"html/template"
 	"io/ioutil"
@@ -12,6 +13,7 @@ import (
 var templateFunctions = map[string]interface{}{
 	"render_file": renderFile,
 	"render_icon": renderIcon,
+	"dict":        dict,
 }
 
 // SetUpTemplateFunction register additional template functions
@@ -46,4 +48,21 @@ func renderIcon(iconName string, options ...string) template.HTML {
 	htmlString := fmt.Sprintf(iconTemplate, classList, iconName)
 
 	return web.Str2html(htmlString)
+}
+
+func dict(values ...interface{}) (map[string]interface{}, error) {
+	if len(values) % 2 != 0 {
+		return nil, errors.New("invalid dict call")
+	}
+
+	dict := make(map[string]interface{}, len(values) / 2)
+	for i := 0; i < len(values); i += 2 {
+		key, ok := values[i].(string)
+		if !ok {
+			return nil, errors.New("dict keys must be strings")
+		}
+		dict[key] = values[i + 1]
+	}
+
+	return dict, nil
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "style-loader": "2.0.0",
         "svg-sprite": "1.5.0",
         "tailwindcss": "2.0.2",
+        "tailwindcss-stimulus-components": "2.1.2",
         "webpack": "5.10.0",
         "webpack-cli": "4.2.0",
         "webpack-merge": "5.4.0"
@@ -8894,6 +8895,15 @@
         "node": ">=12.13.0"
       }
     },
+    "node_modules/tailwindcss-stimulus-components": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss-stimulus-components/-/tailwindcss-stimulus-components-2.1.2.tgz",
+      "integrity": "sha512-nKTZ0VnvwBwfd7KJE4aUnoFIFhW1Q0lhqVk06pLcRm6FLFynV+xdDIxts5Dyj4ZMF7yRFdBvhLimQ71iWfxinQ==",
+      "dev": true,
+      "dependencies": {
+        "stimulus": "^2.0.0"
+      }
+    },
     "node_modules/tailwindcss/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -17329,6 +17339,15 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         }
+      }
+    },
+    "tailwindcss-stimulus-components": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss-stimulus-components/-/tailwindcss-stimulus-components-2.1.2.tgz",
+      "integrity": "sha512-nKTZ0VnvwBwfd7KJE4aUnoFIFhW1Q0lhqVk06pLcRm6FLFynV+xdDIxts5Dyj4ZMF7yRFdBvhLimQ71iWfxinQ==",
+      "dev": true,
+      "requires": {
+        "stimulus": "^2.0.0"
       }
     },
     "tapable": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "style-loader": "2.0.0",
     "svg-sprite": "1.5.0",
     "tailwindcss": "2.0.2",
+    "tailwindcss-stimulus-components": "2.1.2",
     "webpack": "5.10.0",
     "webpack-cli": "4.2.0",
     "webpack-merge": "5.4.0"

--- a/views/keyword/_keywords.html
+++ b/views/keyword/_keywords.html
@@ -50,9 +50,6 @@
           >
             {{ render_icon "eye" }}
           </a>
-          <a href="#" class="table-keyword__icon">
-            {{ render_icon "trash" }}
-          </a>
         </div>
       </td>
     </tr>

--- a/views/keyword/_keywork_links.html
+++ b/views/keyword/_keywork_links.html
@@ -1,0 +1,9 @@
+{{ if .Links }}
+<ul class="tab-link__list-link">
+  {{ range $link := .Links }}
+  <li>
+    <a href="{{ $link }}">{{ $link }}</a>
+  </li>
+  {{ end }}
+</ul>
+{{ else }} No keywords {{ end }}

--- a/views/keyword/html_page.html
+++ b/views/keyword/html_page.html
@@ -1,1 +1,0 @@
-{{str2html .Keyword.HtmlCode}}

--- a/views/keyword/html_page.html
+++ b/views/keyword/html_page.html
@@ -1,0 +1,1 @@
+{{str2html .Keyword.HtmlCode}}

--- a/views/keyword/show.html
+++ b/views/keyword/show.html
@@ -1,40 +1,74 @@
-<div class="card-keyword">
-  <div>Keyword: {{ .KeywordPresenter.Keyword.Keyword }}</div>
-  <div>Status: {{ .KeywordPresenter.Keyword.Status }}</div>
-  <div>Date: {{ date .KeywordPresenter.Keyword.CreatedAt "Y-m-d H:i:s" }}</div>
+<div class="keyword-wrapper">
   <div>
-    HTML:
-    <a href="{{ urlfor `Keyword.ShowHTML` `:id` .Keyword.Id }}">View page</a>
+    <h1 class="keyword-title">{{ .KeywordPresenter.Keyword.Keyword }}</h1>
+    <div>
+      <span class="badge-status badge-status--{{ .Keyword.Status }}"
+        >{{ .KeywordPresenter.Keyword.Status }}</span
+      >
+      at
+      <span class="keyword-date"
+        >{{ date .KeywordPresenter.Keyword.UpdatedAt "Y-m-d H:i:s" }}</span
+      >
+    </div>
+    <a href="{{ urlfor `Keyword.ShowHTML` `:id` .KeywordPresenter.Keyword.Id }}" target="_blank">
+      {{ render_icon "website" "button-html-page" }}
+    </a>
   </div>
-  <div>Total link: {{ .KeywordPresenter.Keyword.LinksCount }}</div>
-  <div>
-    Non-adwords links: {{ .KeywordPresenter.Keyword.NonAdwordLinksCount }}
-    <ul>
-      {{ range $link := .KeywordPresenter.Links.NonAdwordLinks }}
-      <li>
-        <a href="{{ $link }}">{{ $link }}</a>
+  <div
+    data-controller="tabs"
+    data-tabs-active-tab="tab-link__button-tab--active"
+  >
+    <div class="tab-link__title">Total links: {{ .KeywordPresenter.Keyword.LinksCount }}</div>
+    <ul class="tab-link__button-tab-list">
+      <li
+        class="-mb-px mr-1"
+        data-tabs-target="tab"
+        data-action="click->tabs#change"
+      >
+        <a class="tab-link__button-tab" href="#"
+          >Non-adwords({{ .KeywordPresenter.Keyword.NonAdwordLinksCount }})</a
+        >
       </li>
-      {{ end }}
-    </ul>
-  </div>
-  <div>
-    Adwords links: {{ .KeywordPresenter.Keyword.AdwordLinksCount }}
-    <ul>
-      {{ range $link := .KeywordPresenter.Links.AdwordLinks }}
-      <li>
-        <a href="{{ $link }}">{{ $link }}</a>
+      <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
+        <a class="tab-link__button-tab" href="#"
+          >Adwords({{ .KeywordPresenter.Keyword.AdwordLinksCount }})</a
+        >
       </li>
-      {{ end }}
-    </ul>
-  </div>
-  <div>
-    ShopAdwords links: {{ .KeywordPresenter.Keyword.ShopAdwordLinksCount }}
-    <ul>
-      {{ range $link := .KeywordPresenter.Links.ShopAdwordLinks }}
-      <li>
-        <a href="{{ $link }}">{{ $link }}</a>
+      <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
+        <a class="tab-link__button-tab" href="#"
+          >Shop Adwords({{ .KeywordPresenter.Keyword.ShopAdwordLinksCount }})</a
+        >
       </li>
-      {{ end }}
     </ul>
+
+    <div class="hidden tab-link__content" data-tabs-target="panel">
+      <ul class="tab-link____list-link">
+        {{ range $link := .KeywordPresenter.Links.NonAdwordLinks }}
+        <li>
+          <a href="{{ $link }}">{{ $link }}</a>
+        </li>
+        {{ end }}
+      </ul>
+    </div>
+
+    <div class="hidden tab-link__content" data-tabs-target="panel">
+      <ul class="tab-link__list-link">
+        {{ range $index, $link := .KeywordPresenter.Links.AdwordLinks }}
+        <li>
+          <a href="{{ $link }}"> {{ $link }}</a>
+        </li>
+        {{ end }}
+      </ul>
+    </div>
+
+    <div class="hidden tab-link__content" data-tabs-target="panel">
+      <ul class="tab-link____list-link">
+        {{ range $link := .KeywordPresenter.Links.ShopAdwordLinks }}
+        <li>
+          <a href="{{ $link }}">{{ $link }}</a>
+        </li>
+        {{ end }}
+      </ul>
+    </div>
   </div>
 </div>

--- a/views/keyword/show.html
+++ b/views/keyword/show.html
@@ -2,7 +2,8 @@
   <div>
     <h1 class="keyword-title">{{ .KeywordPresenter.Keyword.Keyword }}</h1>
     <div>
-      <span class="badge-status badge-status--{{ .Keyword.Status }}"
+      <span
+        class="badge-status badge-status--{{ .KeywordPresenter.Keyword.Status }}"
         >{{ .KeywordPresenter.Keyword.Status }}</span
       >
       at
@@ -10,7 +11,10 @@
         >{{ date .KeywordPresenter.Keyword.UpdatedAt "Y-m-d H:i:s" }}</span
       >
     </div>
-    <a href="{{ urlfor `Keyword.ShowHTML` `:id` .KeywordPresenter.Keyword.Id }}" target="_blank">
+    <a
+      href="{{ urlfor `Keyword.ShowHTML` `:id` .KeywordPresenter.Keyword.Id }}"
+      target="_blank"
+    >
       {{ render_icon "website" "button-html-page" }}
     </a>
   </div>
@@ -18,7 +22,9 @@
     data-controller="tabs"
     data-tabs-active-tab="tab-link__button-tab--active"
   >
-    <div class="tab-link__title">Total links: {{ .KeywordPresenter.Keyword.LinksCount }}</div>
+    <div class="tab-link__title">
+      Total links: {{ .KeywordPresenter.Keyword.LinksCount }}
+    </div>
     <ul class="tab-link__button-tab-list">
       <li
         class="-mb-px mr-1"
@@ -42,15 +48,15 @@
     </ul>
 
     <div class="hidden tab-link__content" data-tabs-target="panel">
-      {{ template "keyword/_keywork_links.html" dict "Links" .KeywordPresenter.KeywordLinks.NonAdwordLinks }}
+      {{ template "keyword/_keywork_links.html" dict "Links" .KeywordPresenter.Links.NonAdwordLinks }}
     </div>
 
     <div class="hidden tab-link__content" data-tabs-target="panel">
-      {{ template "keyword/_keywork_links.html" dict "Links" .KeywordPresenter.KeywordLinks.AdwordLinks }}
+      {{ template "keyword/_keywork_links.html" dict "Links" .KeywordPresenter.Links.AdwordLinks }}
     </div>
 
     <div class="hidden tab-link__content" data-tabs-target="panel">
-      {{ template "keyword/_keywork_links.html" dict "Links" .KeywordPresenter.KeywordLinks.ShopAdwordLinks }}
+      {{ template "keyword/_keywork_links.html" dict "Links" .KeywordPresenter.Links.ShopAdwordLinks }}
     </div>
   </div>
 </div>

--- a/views/keyword/show.html
+++ b/views/keyword/show.html
@@ -42,33 +42,15 @@
     </ul>
 
     <div class="hidden tab-link__content" data-tabs-target="panel">
-      <ul class="tab-link____list-link">
-        {{ range $link := .KeywordPresenter.Links.NonAdwordLinks }}
-        <li>
-          <a href="{{ $link }}">{{ $link }}</a>
-        </li>
-        {{ end }}
-      </ul>
+      {{ template "keyword/_keywork_links.html" dict "Links" .KeywordPresenter.KeywordLinks.NonAdwordLinks }}
     </div>
 
     <div class="hidden tab-link__content" data-tabs-target="panel">
-      <ul class="tab-link__list-link">
-        {{ range $index, $link := .KeywordPresenter.Links.AdwordLinks }}
-        <li>
-          <a href="{{ $link }}"> {{ $link }}</a>
-        </li>
-        {{ end }}
-      </ul>
+      {{ template "keyword/_keywork_links.html" dict "Links" .KeywordPresenter.KeywordLinks.AdwordLinks }}
     </div>
 
     <div class="hidden tab-link__content" data-tabs-target="panel">
-      <ul class="tab-link____list-link">
-        {{ range $link := .KeywordPresenter.Links.ShopAdwordLinks }}
-        <li>
-          <a href="{{ $link }}">{{ $link }}</a>
-        </li>
-        {{ end }}
-      </ul>
+      {{ template "keyword/_keywork_links.html" dict "Links" .KeywordPresenter.KeywordLinks.ShopAdwordLinks }}
     </div>
   </div>
 </div>

--- a/views/keyword/show.html
+++ b/views/keyword/show.html
@@ -48,15 +48,15 @@
     </ul>
 
     <div class="hidden tab-link__content" data-tabs-target="panel">
-      {{ template "keyword/_keywork_links.html" dict "Links" .KeywordPresenter.Links.NonAdwordLinks }}
+      {{ template "keyword/_keywork_links.html" args "Links" .KeywordPresenter.Links.NonAdwordLinks }}
     </div>
 
     <div class="hidden tab-link__content" data-tabs-target="panel">
-      {{ template "keyword/_keywork_links.html" dict "Links" .KeywordPresenter.Links.AdwordLinks }}
+      {{ template "keyword/_keywork_links.html" args "Links" .KeywordPresenter.Links.AdwordLinks }}
     </div>
 
     <div class="hidden tab-link__content" data-tabs-target="panel">
-      {{ template "keyword/_keywork_links.html" dict "Links" .KeywordPresenter.Links.ShopAdwordLinks }}
+      {{ template "keyword/_keywork_links.html" args "Links" .KeywordPresenter.Links.ShopAdwordLinks }}
     </div>
   </div>
 </div>

--- a/views/shared/_pagination.html
+++ b/views/shared/_pagination.html
@@ -12,7 +12,7 @@
       <nav class="pagination__nav" aria-label="Pagination">
         <a
           href="{{ .paginator.PageLinkPrev }}"
-          class="pagination__item pagination__item--nav pagination__item--nav-left {{ if .paginator.HasPrev }} pagination__item--disabled {{ end }}"
+          class="pagination__item pagination__item--nav pagination__item--nav-left {{ if not .paginator.HasPrev }} pagination__item--disabled {{ end }}"
         >
           <span class="sr-only">Previous</span>
           {{ render_icon "chevron-left" "w-5 h-5" }}
@@ -27,7 +27,7 @@
         {{ end }}
         <a
           href="{{ .paginator.PageLinkNext }}"
-          class="pagination__item pagination__item--nav pagination__item--nav-right {{ if .paginator.HasNext }} pagination__item--disabled {{ end }}"
+          class="pagination__item pagination__item--nav pagination__item--nav-right {{ if not .paginator.HasNext }} pagination__item--disabled {{ end }}"
         >
           <span class="sr-only">Next</span>
           {{ render_icon "chevron-right" "w-5 h-5" }}

--- a/views/shared/header.html
+++ b/views/shared/header.html
@@ -9,7 +9,6 @@
           {{ if .CurrentUser }}
           <div class="navigation-menu__items">
             <div class="menu-items">
-              <!-- Current: "bg-gray-900 text-white", Default: "text-gray-300 hover:bg-gray-700 hover:text-white" -->
               <a href="/" class="menu-items__item menu-items__item--active"
                 >Dashboard</a
               >

--- a/views/shared/header.html
+++ b/views/shared/header.html
@@ -10,7 +10,7 @@
           <div class="navigation-menu__items">
             <div class="menu-items">
               <!-- Current: "bg-gray-900 text-white", Default: "text-gray-300 hover:bg-gray-700 hover:text-white" -->
-              <a href="#" class="menu-items__item menu-items__item--active"
+              <a href="/" class="menu-items__item menu-items__item--active"
                 >Dashboard</a
               >
             </div>


### PR DESCRIPTION
Resolve #35 

## What happened 👀

Implement UI for keyword detail

## Insight 📝

- Create `_keyword_links` partial to render links
- Create `dict` template function to get the params and pass to partial
https://github.com/beego/wetalk/blob/master/modules/utils/template.go#L73
- Add `tailwindcss-stimulus-components` to implement `tabs` faster
- 

## Proof Of Work 📹

![Go_Scraper](https://user-images.githubusercontent.com/7344405/111253109-25349300-8645-11eb-8aef-465046b819a5.png)

