### PR TITLE
Rename db folder to match the Gin template directories

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -3,7 +3,7 @@ package bootstrap
 import (
 	"fmt"
 
-	"github.com/hoangmirs/go-scraper/db"
+	"github.com/hoangmirs/go-scraper/database"
 	"github.com/hoangmirs/go-scraper/helpers"
 	_ "github.com/hoangmirs/go-scraper/routers" // Routers
 	"github.com/hoangmirs/go-scraper/services/jobenqueuer"
@@ -21,8 +21,8 @@ func init() {
 }
 
 func SetUp() {
-	db.SetUpDB()
-	db.SetupRedisPool()
+	database.SetUpDB()
+	database.SetupRedisPool()
 	jobenqueuer.SetUpEnqueuer()
 	SetUpTemplateFunction()
 }

--- a/database/db.go
+++ b/database/db.go
@@ -1,4 +1,4 @@
-package db
+package database
 
 import (
 	"fmt"

--- a/database/redis.go
+++ b/database/redis.go
@@ -1,4 +1,4 @@
-package db
+package database
 
 import (
 	"github.com/beego/beego/v2/server/web"

--- a/services/jobenqueuer/job_enqueuer.go
+++ b/services/jobenqueuer/job_enqueuer.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/hoangmirs/go-scraper/conf"
-	"github.com/hoangmirs/go-scraper/db"
+	"github.com/hoangmirs/go-scraper/database"
 	"github.com/hoangmirs/go-scraper/models"
 
 	"github.com/beego/beego/v2/core/logs"
@@ -16,7 +16,7 @@ var enqueuer *work.Enqueuer
 // SetUpEnqueuer sets up a new job enqueuer, will be run when initializing application
 func SetUpEnqueuer() {
 	if enqueuer == nil {
-		enqueuer = work.NewEnqueuer(conf.GetString("workerNamespace"), db.GetRedisPool())
+		enqueuer = work.NewEnqueuer(conf.GetString("workerNamespace"), database.GetRedisPool())
 	}
 }
 

--- a/tests/test_helpers/worker_helper.go
+++ b/tests/test_helpers/worker_helper.go
@@ -2,18 +2,18 @@ package test_helpers
 
 import (
 	"github.com/hoangmirs/go-scraper/conf"
-	"github.com/hoangmirs/go-scraper/db"
+	"github.com/hoangmirs/go-scraper/database"
 
 	"github.com/beego/beego/v2/core/logs"
 	"github.com/gocraft/work"
 )
 
 func GetWorkerClient() *work.Client {
-	return work.NewClient(conf.GetString("workerNamespace"), db.GetRedisPool())
+	return work.NewClient(conf.GetString("workerNamespace"), database.GetRedisPool())
 }
 
 func DeleteRedisJobs() {
-	_, err := db.GetRedisPool().Get().Do("DEL", redisKeyJobs(conf.GetString("workerNamespace"), conf.GetString("scraperJobName")))
+	_, err := database.GetRedisPool().Get().Do("DEL", redisKeyJobs(conf.GetString("workerNamespace"), conf.GetString("scraperJobName")))
 	if err != nil {
 		logs.Error("Error when deleting redis jobs: %v", err)
 	}

--- a/workers/main.go
+++ b/workers/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hoangmirs/go-scraper/bootstrap"
 	"github.com/hoangmirs/go-scraper/conf"
-	"github.com/hoangmirs/go-scraper/db"
+	"github.com/hoangmirs/go-scraper/database"
 	"github.com/hoangmirs/go-scraper/workers/jobs"
 
 	"github.com/gocraft/work"
@@ -19,7 +19,7 @@ var redisPool = &redis.Pool{
 	MaxActive: 5,
 	MaxIdle:   5,
 	Wait:      true,
-	Dial:      db.GetRedisConnection,
+	Dial:      database.GetRedisConnection,
 }
 
 func init() {


### PR DESCRIPTION
Resolve #44 

## What happened 👀

Rename `db` folder to match the Gin template directories

## Insight 📝

- Rename `db` -> `database`
- Cannot rename `conf` folder because beego use fixed folder `conf` in some places on their code
![beego_go_—_go-scraper](https://user-images.githubusercontent.com/7344405/112094253-87554100-8bcd-11eb-9bf6-290100e81ac4.png)


## Proof Of Work 📹

Tests should be passed