### PR TITLE
As an API user, I can register

### DIFF
--- a/controllers/api/v1/base.go
+++ b/controllers/api/v1/base.go
@@ -3,7 +3,6 @@ package apiv1controllers
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"strconv"
 
@@ -67,18 +66,16 @@ func (c *baseController) ensureAuthenticatedUser() bool {
 	return true
 }
 
-func (c *baseController) ensureAuthenticatedClient() error {
+func (c *baseController) ensureAuthenticatedClient() {
 	clientID, clientSecret, err := oauth.GetOAuthServer().ClientInfoHandler(c.Ctx.Request)
 	if err != nil {
-		return err
+		c.renderError("Unauthorized client", err.Error(), "unauthorized_client", http.StatusUnauthorized, nil)
 	}
 
 	client, err := oauth.GetClientStore().GetByID(context.TODO(), clientID)
 	if err != nil || client.GetSecret() != clientSecret {
-		return errors.New("Client authentication failed")
+		c.renderError("Unauthorized client", "Client authentication failed", "unauthorized_client", http.StatusUnauthorized, nil)
 	}
-
-	return nil
 }
 
 func (c *baseController) renderJSON(data interface{}) error {

--- a/controllers/api/v1/oauth_token.go
+++ b/controllers/api/v1/oauth_token.go
@@ -53,10 +53,7 @@ func (c *OAuthToken) Post() {
 }
 
 func (c *OAuthToken) Revoke() {
-	err := c.ensureAuthenticatedClient()
-	if err != nil {
-		c.renderError("Unauthorized client", err.Error(), "unauthorized_client", http.StatusUnauthorized, nil)
-	}
+	c.ensureAuthenticatedClient()
 
 	server := oauth.GetOAuthServer()
 	tokenInfo, err := server.ValidationBearerToken(c.Ctx.Request)

--- a/controllers/api/v1/user.go
+++ b/controllers/api/v1/user.go
@@ -1,0 +1,28 @@
+package apiv1controllers
+
+import (
+	"net/http"
+
+	"github.com/hoangmirs/go-scraper/forms"
+)
+
+type User struct {
+	baseController
+}
+
+func (c *User) Post() {
+	c.ensureAuthenticatedClient()
+
+	registrationForm := forms.RegistrationForm{}
+	err := c.ParseForm(&registrationForm)
+	if err != nil {
+		c.renderGenericError(err)
+	}
+
+	_, err = registrationForm.CreateUser()
+	if err != nil {
+		c.renderError("Validation error", err.Error(), "validation_error", http.StatusUnprocessableEntity, nil)
+	}
+
+	c.Ctx.ResponseWriter.WriteHeader(http.StatusCreated)
+}

--- a/controllers/api/v1/user_test.go
+++ b/controllers/api/v1/user_test.go
@@ -129,7 +129,7 @@ var _ = Describe("UserController", func() {
 				})
 			})
 
-			Context("given an invalid user information", func() {
+			Context("given an INVALID user information", func() {
 				It("returns status UnprocessableEntity", func() {
 					client := fabricators.FabricateOAuthClient(uuid.New().String(), uuid.New().String())
 

--- a/controllers/api/v1/user_test.go
+++ b/controllers/api/v1/user_test.go
@@ -1,0 +1,183 @@
+package apiv1controllers_test
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	. "github.com/hoangmirs/go-scraper/tests/custom_matchers"
+	"github.com/hoangmirs/go-scraper/tests/fabricators"
+	. "github.com/hoangmirs/go-scraper/tests/test_helpers"
+
+	"github.com/beego/beego/v2/client/orm"
+	"github.com/bxcodec/faker/v3"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("UserController", func() {
+	AfterEach(func() {
+		TruncateTables("user", "oauth2_clients", "oauth2_tokens")
+	})
+
+	Describe("POST", func() {
+		Context("given valid credentials", func() {
+			Context("given a valid user information", func() {
+				It("returns status Created", func() {
+					client := fabricators.FabricateOAuthClient(uuid.New().String(), uuid.New().String())
+					email := faker.Email()
+					password := faker.Password()
+
+					form := url.Values{
+						"client_id":             {client.ID},
+						"client_secret":         {client.Secret},
+						"email":                 {email},
+						"password":              {password},
+						"password_confirmation": {password},
+					}
+					body := strings.NewReader(form.Encode())
+
+					response := MakeRequest("POST", "/api/v1/users", body)
+
+					Expect(response.Code).To(Equal(http.StatusCreated))
+				})
+
+				It("returns empty response", func() {
+					client := fabricators.FabricateOAuthClient(uuid.New().String(), uuid.New().String())
+					email := faker.Email()
+					password := faker.Password()
+
+					form := url.Values{
+						"client_id":             {client.ID},
+						"client_secret":         {client.Secret},
+						"email":                 {email},
+						"password":              {password},
+						"password_confirmation": {password},
+					}
+					body := strings.NewReader(form.Encode())
+
+					response := MakeRequest("POST", "/api/v1/users", body)
+
+					Expect(response.Body.String()).To(BeEmpty())
+				})
+
+				It("creates a new user record", func() {
+					client := fabricators.FabricateOAuthClient(uuid.New().String(), uuid.New().String())
+					email := faker.Email()
+					password := faker.Password()
+
+					form := url.Values{
+						"client_id":             {client.ID},
+						"client_secret":         {client.Secret},
+						"email":                 {email},
+						"password":              {password},
+						"password_confirmation": {password},
+					}
+					body := strings.NewReader(form.Encode())
+
+					_ = MakeRequest("POST", "/api/v1/users", body)
+
+					userCount, err := orm.NewOrm().QueryTable("user").Count()
+					if err != nil {
+						Fail("Failed to count users: " + err.Error())
+					}
+
+					Expect(userCount).To(BeNumerically("==", 1))
+				})
+			})
+
+			Context("given an existing user information", func() {
+				It("returns status UnprocessableEntity", func() {
+					client := fabricators.FabricateOAuthClient(uuid.New().String(), uuid.New().String())
+					email := faker.Email()
+					password := faker.Password()
+					_ = fabricators.FabricateUser(email, password)
+
+					form := url.Values{
+						"client_id":             {client.ID},
+						"client_secret":         {client.Secret},
+						"email":                 {email},
+						"password":              {password},
+						"password_confirmation": {password},
+					}
+					body := strings.NewReader(form.Encode())
+
+					response := MakeRequest("POST", "/api/v1/users", body)
+
+					Expect(response.Code).To(Equal(http.StatusUnprocessableEntity))
+				})
+
+				It("returns correct response", func() {
+					client := fabricators.FabricateOAuthClient(uuid.New().String(), uuid.New().String())
+					email := faker.Email()
+					password := faker.Password()
+					_ = fabricators.FabricateUser(email, password)
+
+					form := url.Values{
+						"client_id":             {client.ID},
+						"client_secret":         {client.Secret},
+						"email":                 {email},
+						"password":              {password},
+						"password_confirmation": {password},
+					}
+					body := strings.NewReader(form.Encode())
+
+					response := MakeRequest("POST", "/api/v1/users", body)
+
+					Expect(response).To(MatchJSONSchema("error/json_api"))
+				})
+			})
+
+			Context("given an invalid user information", func() {
+				It("returns status UnprocessableEntity", func() {
+					client := fabricators.FabricateOAuthClient(uuid.New().String(), uuid.New().String())
+
+					form := url.Values{
+						"client_id":             {client.ID},
+						"client_secret":         {client.Secret},
+						"email":                 {"email"},
+						"password":              {"password"},
+						"password_confirmation": {""},
+					}
+					body := strings.NewReader(form.Encode())
+
+					response := MakeRequest("POST", "/api/v1/users", body)
+
+					Expect(response.Code).To(Equal(http.StatusUnprocessableEntity))
+				})
+
+				It("returns correct response", func() {
+					client := fabricators.FabricateOAuthClient(uuid.New().String(), uuid.New().String())
+
+					form := url.Values{
+						"client_id":             {client.ID},
+						"client_secret":         {client.Secret},
+						"email":                 {"email"},
+						"password":              {"password"},
+						"password_confirmation": {""},
+					}
+					body := strings.NewReader(form.Encode())
+
+					response := MakeRequest("POST", "/api/v1/users", body)
+
+					Expect(response).To(MatchJSONSchema("error/json_api"))
+				})
+			})
+		})
+
+		Context("given INVALID credentials", func() {
+			It("returns status Unauthorized", func() {
+				form := url.Values{
+					"client_id":     {"invalid"},
+					"client_secret": {"invalid"},
+				}
+				body := strings.NewReader(form.Encode())
+
+				response := MakeRequest("POST", "/api/v1/users", body)
+
+				Expect(response.Code).To(Equal(http.StatusUnauthorized))
+			})
+		})
+	})
+})

--- a/routers/router.go
+++ b/routers/router.go
@@ -20,6 +20,7 @@ func init() {
 	// API V1
 	ns := web.NewNamespace("/api/v1",
 		web.NSRouter("/health_check", &apiv1controllers.HealthCheck{}),
+		web.NSRouter("/users", &apiv1controllers.User{}),
 
 		web.NSNamespace("/oauth",
 			web.NSRouter("/client", &apiv1controllers.OAuthClient{}),


### PR DESCRIPTION
Resolve #13 

## What happened 👀

As an API user, I can register

## Insight 📝

- Add `POST /api/v1/users` to create new user that requires the following parameters
```
client_id
client_secret
email
password
password_confirmation
```
- Refactor some code

## Proof Of Work 📹

![Postman](https://user-images.githubusercontent.com/7344405/113857624-eff70d00-97cc-11eb-8e56-9dd251b54318.png)

